### PR TITLE
schema and tables modified to add created_at

### DIFF
--- a/site/prisma/migrations/20230817211453_init/migration.sql
+++ b/site/prisma/migrations/20230817211453_init/migration.sql
@@ -2,6 +2,7 @@
 CREATE TABLE "rooms" (
     "room_id" SERIAL NOT NULL,
     "current_question" INTEGER NOT NULL DEFAULT 0,
+    "created_at" TIMESTAMP NOT NULL,
 
     CONSTRAINT "rooms_pkey" PRIMARY KEY ("room_id")
 );

--- a/site/prisma/schema.prisma
+++ b/site/prisma/schema.prisma
@@ -13,8 +13,9 @@ datasource db {
 }
 
 model rooms {
-  room_id     Int     @id @default(autoincrement())
-  current_question Int @default(0) // 0 means the game has not started
+  room_id          Int      @id @default(autoincrement())
+  current_question Int      @default(0) // 0 means the game has not started
+  created_at       DateTime @default(now()) // Add the created_at field with the current timestamp
 }
 
 model questions {


### PR DESCRIPTION
Add created_at to Prisma schema and SQL query 

model rooms {
  room_id          Int      @id @default(autoincrement())
  current_question Int      @default(0) // 0 means the game has not started
  created_at       DateTime @default(now()) // Add the created_at field with the current timestamp
}


-- CreateTable
CREATE TABLE "rooms" (
    "room_id" SERIAL NOT NULL,
    "current_question" INTEGER NOT NULL DEFAULT 0,
    "created_at" TIMESTAMP NOT NULL,

    CONSTRAINT "rooms_pkey" PRIMARY KEY ("room_id")
);